### PR TITLE
More Python 3 fixes

### DIFF
--- a/src/infi/devicemanager/ioctl/__init__.py
+++ b/src/infi/devicemanager/ioctl/__init__.py
@@ -8,7 +8,7 @@ def ioctl_scsi_get_address(handle):
     size = _sizeof(structures.SCSI_ADDRESS)
     instance = structures.SCSI_ADDRESS.create_from_string(b'\x00' * size)
     instance.Length = size
-    string = ctypes.c_buffer(structures.SCSI_ADDRESS.write_to_string(instance), size)
+    string = ctypes.c_buffer(structures.SCSI_ADDRESS.write_to_string(instance), size).raw
     try:
         _ = infi.wioctl.ioctl(handle, infi.wioctl.constants.IOCTL_SCSI_GET_ADDRESS, 0, 0, string, size)
     except infi.wioctl.errors.WindowsException as exception:
@@ -19,14 +19,14 @@ def ioctl_scsi_get_address(handle):
 
 def ioctl_storage_get_device_number(handle):
     size = _sizeof(structures.STORAGE_DEVICE_NUMBER)
-    string = ctypes.c_buffer(b'\x00' * size, size)
+    string = ctypes.c_buffer(b'\x00' * size, size).raw
     _ = infi.wioctl.ioctl(handle, infi.wioctl.constants.IOCTL_STORAGE_GET_DEVICE_NUMBER, 0, 0, string, size)
     instance = structures.STORAGE_DEVICE_NUMBER.create_from_string(string)
     return (instance.DeviceNumber, instance.PartitionNumber,)
 
 def ioctl_disk_get_drive_geometry_ex(handle):
     size = _sizeof(structures.DISK_GEOMETRY_EX)
-    string = ctypes.c_buffer('\x00' * size, size)
+    string = ctypes.c_buffer(b'\x00' * size, size).raw
     try:
         # this IOCTL expects a variable-length buffer for storing infomation about partitions
         # we don't care about that, so we send a short buffer on purpose. this raises an exception

--- a/src/infi/devicemanager/setupapi/functions.py
+++ b/src/infi/devicemanager/setupapi/functions.py
@@ -24,7 +24,7 @@ def pretty_string_to_guid(pretty_string):
 
 def guid_to_pretty_string(guid):
     from binascii import hexlify
-    pretty_string = hexlify(GUID.write_to_string(guid)).upper()
+    pretty_string = hexlify(GUID.write_to_string(guid)).upper().decode('ASCII')
     pretty_string = pretty_string[0:2][::-1] + pretty_string[2:4][::-1] + pretty_string[4:6][::-1] + \
                     pretty_string[6:8][::-1] + pretty_string[8:10][::-1] + pretty_string[10:12][::-1] + \
                     pretty_string[12:14][::-1] + pretty_string[14:16][::-1] + pretty_string[16:]
@@ -66,7 +66,7 @@ def SetupDiEnumDeviceInfo(device_info_set, index=0):
     from . import SetupDiEnumDeviceInfo as interface
     device_info_data = SP_DEVINFO_DATA.create_from_string(b'\x00' * SP_DEVINFO_DATA.min_max_sizeof().max)
     device_info_data.cbSize = SP_DEVINFO_DATA.min_max_sizeof().max
-    device_info_buffer = c_buffer(SP_DEVINFO_DATA.write_to_string(device_info_data), SP_DEVINFO_DATA.min_max_sizeof().max)
+    device_info_buffer = c_buffer(SP_DEVINFO_DATA.write_to_string(device_info_data), SP_DEVINFO_DATA.min_max_sizeof().max).raw
     interface(device_info_set, index, device_info_buffer)
     return SP_DEVINFO_DATA.create_from_string(device_info_buffer)
 
@@ -85,7 +85,7 @@ def SetupDiGetDevicePropertyKeys(device_info_set, devinfo_data):
     class PropertyKeyArray(Struct):
         _fields_ = [FixedSizeArray("keys", required_key_count.value, DEVPROPKEY)]
 
-    keys_buffer = c_buffer(b'\x00' * PropertyKeyArray.min_max_sizeof().max, PropertyKeyArray.min_max_sizeof().max)
+    keys_buffer = c_buffer(b'\x00' * PropertyKeyArray.min_max_sizeof().max, PropertyKeyArray.min_max_sizeof().max).raw
     interface(device_info_set, device_info_buffer, keys_buffer, required_key_count,
               byref(required_key_count), 0)
     return PropertyKeyArray.create_from_string(keys_buffer).keys
@@ -116,7 +116,7 @@ def SetupDiOpenDeviceInfo(device_info_set, instance_id, flags=DIOD_INHERIT_CLASS
     instance_id_buffer = create_unicode_buffer(instance_id)
     device_info_data = SP_DEVINFO_DATA.create_from_string(b'\x00' * SP_DEVINFO_DATA.min_max_sizeof().max)
     device_info_data.cbSize = SP_DEVINFO_DATA.min_max_sizeof().max
-    device_info_buffer = c_buffer(SP_DEVINFO_DATA.write_to_string(device_info_data), SP_DEVINFO_DATA.min_max_sizeof().max)
+    device_info_buffer = c_buffer(SP_DEVINFO_DATA.write_to_string(device_info_data), SP_DEVINFO_DATA.min_max_sizeof().max).raw
     interface(device_info_set, instance_id_buffer, 0, flags, device_info_buffer)
     return SP_DEVINFO_DATA.create_from_string(device_info_buffer)
 
@@ -153,7 +153,7 @@ class Property(object):
         if self._type in [properties.DEVPROP_TYPE_STRING]:
             return self._buffer.decode("utf-16")[:-1]
         if self._type in [properties.DEVPROP_TYPE_STRING_LIST]:
-            return self._buffer.decode("utf-16")[:-1].split(unichr(0))[:-1]
+            return self._buffer.decode("utf-16")[:-1].split(chr(0))[:-1]
         if self._type in [properties.DEVPROP_TYPE_GUID]:
             return GUID.create_from_string(self._buffer)
         if self._type in [properties.DEVPROP_TYPE_UINT32,

--- a/src/infi/devicemanager/tests.py
+++ b/src/infi/devicemanager/tests.py
@@ -1,9 +1,16 @@
 
 import unittest
 import mock
+import sys
 
 from . import DeviceManager
 from .ioctl import DeviceIoControl
+
+if sys.version_info[0] == 2:
+    _STRING_INSTANCE = basestring
+else:
+    _STRING_INSTANCE = str
+
 
 class TestCase(unittest.TestCase):
     def setUp(self):
@@ -37,7 +44,7 @@ class TestCase(unittest.TestCase):
             try:
                 size = DeviceIoControl(disk.psuedo_device_object).disk_get_drive_geometry_ex()
                 self.assertTrue(isinstance(size, int) or isinstance(size, long))
-            except WindowsException, error:
+            except WindowsException as error:
                 if error.winerror == 1:
                     # If there is MPIO disk, we cannot do IOCTLs on underlying SCSI disks
                     continue
@@ -50,7 +57,7 @@ class TestCase(unittest.TestCase):
         for device in devices:
             prop_list = device.get_available_property_ids()
             self.assertGreater(len(prop_list), 0)
-            self.assertIsInstance(prop_list[0], str)
+            self.assertIsInstance(prop_list[0], _STRING_INSTANCE)
 
     def test_rescan__storage(self):
         dm = DeviceManager()


### PR DESCRIPTION
All tests seems to work now in Python 2 and 3. I made a small fix in infi.wioctl and pushed it directly to develop. This package should be tested with the latest version of infi.wioctl.