### PR TITLE
Support ULInt64

### DIFF
--- a/src/infi/devicemanager/setupapi/functions.py
+++ b/src/infi/devicemanager/setupapi/functions.py
@@ -146,7 +146,7 @@ class Property(object):
 
     def _get_python_object(self):
         from . import properties
-        from .structures import Struct, FixedSizeArray, ULInt32, ULInt8
+        from .structures import Struct, FixedSizeArray, ULInt32, ULInt64, ULInt8
         from .structures import FILETIME, SECURITY_DESCRIPTOR
         from . import ConvertStringSecurityDescriptorToSecurityDescriptorW as ConvertSDDL
         from .constants import SDDL_REVISION_1
@@ -161,6 +161,10 @@ class Property(object):
                           properties.DEVPROP_TYPE_NTSTATUS]:
             class Value(Struct):
                 _fields_ = [ULInt32("value")]
+            return Value.create_from_string(self._buffer).value
+        if self._type in [properties.DEVPROP_TYPE_UINT64]:
+            class Value(Struct):
+                _fields_ = [ULInt64("value")]
             return Value.create_from_string(self._buffer).value
         if self._type in [properties.DEVPROP_TYPE_BINARY]:
             class Value(Struct):
@@ -179,5 +183,5 @@ class Property(object):
             ConvertSDDL(c_buffer(self._buffer), SDDL_REVISION_1, sd_buffer, 0)
             # TODO requires to call LocalFree
             return SECURITY_DESCRIPTOR.create_from_string(sd_buffer)
-        log = debug("{!r}. {!r}, {!r}".format(self._buffer, self._type, self._key))
+        log.debug("{!r}. {!r}, {!r}".format(self._buffer, self._type, self._key))
         raise ValueError(self._buffer, self._type)


### PR DESCRIPTION
This PR supports `properties.DEVPROP_TYPE_UINT64` and fix a minor bug.

I tweak / improve this repo because my below code cannot run correctly without this fix. The issue is:
`device._get_setupapi_property(luid_key)` returns an UINT64 value which was not covered in the original source code.

```python
import wmi
from infi.devicemanager import Device
from infi.devicemanager.setupapi import functions, structures

guid = functions.pretty_string_to_guid('60B193CB-5276-4D0F-96FC-F173ABAD3EC6')
luid_key = structures.DEVPROPKEY(
    Data1=guid.Data1,
    Data2=guid.Data2,
    Data3=guid.Data3,
    Data4=guid.Data4,
    pid=2
)

cards = wmi.WMI().query('SELECT Name, PNPDeviceID FROM Win32_VideoController')
for i, card in enumerate(cards):
    device = Device(card.PNPDeviceID)
    luid = '{:016x}'.format(device._get_setupapi_property(luid_key)) # <-- returns an UINT64 value
    luid = ('0x{}_0x{}').format(luid[:8], luid[8:])
    self._gpu_luids.update({luid : i})
    self.gpu_cards.update({i : 'luid_{} | {}'.format(luid, card.Name)})
```